### PR TITLE
Add polyfill for String.endsWith

### DIFF
--- a/util.js
+++ b/util.js
@@ -1,6 +1,20 @@
 define(['underscore'], function(_) {
     "use strict";
 
+    // String.endsWith Polyfill for IE.
+    // Source: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
+    if (!String.prototype.endsWith) {
+      String.prototype.endsWith = function(searchString, position) {
+          var subjectString = this.toString();
+          if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+            position = subjectString.length;
+          }
+          position -= searchString.length;
+          var lastIndex = subjectString.indexOf(searchString, position);
+          return lastIndex !== -1 && lastIndex === position;
+      };
+    }
+
     // Differs from the underscore `find` in that this version will return
     // the first non-falsy result, instead of an item from `collection`.
     // Synonymous to: _.filter(_.map(collection, predicate))[0]


### PR DESCRIPTION
- This method is not available in IE and was preventing
  the plugin from loading.

**Testing instructions**
- View the website in IE, and verify that the plugin loads and functions correctly.

To test and make changes to this plugin now that it's in a separate repo, I've been cloning it into the `plugin` directory of a GeositeFramework installation. One catch is that you'll need to rename `sample_layers.json` to `layers.json`.

![image](https://cloud.githubusercontent.com/assets/1042475/14323129/4d9ae8d6-fbed-11e5-931d-fb4b4b58673e.png)

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/626
