### PR TITLE
Only show layer tools on hover.

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
     "css": [
-        "plugins/layer_selector_v2/fontello-8ae227d1/css/layer-selector-v2.css",
-        "plugins/layer_selector_v2/style.css",
-        "plugins/layer_selector_v2/draw_report/style.css"
+        "plugins/regional-planning/fontello-8ae227d1/css/layer-selector-v2.css",
+        "plugins/regional-planning/style.css",
+        "plugins/regional-planning/draw_report/style.css"
     ]
 }

--- a/style.css
+++ b/style.css
@@ -75,7 +75,6 @@
             width: auto;
         }
         .layer-selector2 .tree-container li.leaf-node:hover > .layer-tools,
-        .layer-selector2 .tree-container li.leaf-node.selected > .layer-tools,
         .layer-selector2 .tree-container li.leaf-node.active > .layer-tools {
             display: block;
         }


### PR DESCRIPTION
- Fixes an issue where layer names are cut off by the layer tools. This
  seems unavoidable on hover, but the layer tools do not need to be shown
  for layers that are selected. Reference the original wireframes.

Before (ignore the numbers after the layer names):

![image](https://cloud.githubusercontent.com/assets/1042475/14325248/6eff3474-fbf6-11e5-90c3-da550ab42d8d.png)

After:

![image](https://cloud.githubusercontent.com/assets/1042475/14325202/3b237c64-fbf6-11e5-929c-58848982c58f.png)

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/611
