### PR TITLE
Show error message for unavailable service.

### DIFF
--- a/AgsService.js
+++ b/AgsService.js
@@ -28,7 +28,17 @@ define([
 
             // Return cached map service data.
             getServiceData: function() {
-                return ajaxUtil.get(this.getServiceUrl());
+                var serviceUrl = this.getServiceUrl();
+
+                // If service information is only partially
+                // defined or the config is bad for this
+                // service, don't bother getting the data
+                // because it the response is an error.
+                if (serviceUrl.match(/undefined/) === null) {
+                    return ajaxUtil.get(this.getServiceUrl());
+                }
+
+                return null;
             },
 
             // Return a promise with service layer data.
@@ -59,6 +69,12 @@ define([
 
                 if (!serviceData || !layer) {
                     return null;
+                } else if (serviceData instanceof Error) {
+                    // If the response from the server was an
+                    // error, the service is unavailable.
+                    return {
+                        isUnavailable: true
+                    };
                 }
 
                 return _.find(serviceData.layers, function(serviceLayer) {

--- a/LayerNode.js
+++ b/LayerNode.js
@@ -226,6 +226,10 @@ define([
 
             getDownloadUrl: function() {
                 return this.node.downloadUrl;
+            },
+
+            isUnavailable: function() {
+                return !!this.node.isUnavailable;
             }
         });
 

--- a/main.js
+++ b/main.js
@@ -100,14 +100,16 @@ define([
             bindTreeEvents: function() {
                 var self = this;
 
-                function toggleLayer() {
-                    var layerId = self.getClosestLayerId(this),
-                        layer = self.tree.findLayer(layerId);
-                    self.toggleLayer(layer);
-                }
-
                 $(this.container)
-                    .on('click', 'a.layer-row', toggleLayer)
+                    .on('click', 'a.layer-row', function() {
+                        if ($(this).parent().hasClass('unavailable')) {
+                            return;
+                        }
+
+                        var layerId = self.getClosestLayerId(this),
+                            layer = self.tree.findLayer(layerId);
+                        self.toggleLayer(layer);
+                    })
                     .on('click', 'a.info', function() {
                         self.state = self.state.setInfoBoxLayerId(self.getClosestLayerId(this));
                         self.showLayerInfo();
@@ -376,6 +378,7 @@ define([
             renderLayer: function(indent, layer) {
                 var isSelected = layer.isSelected(),
                     isExpanded = layer.isExpanded(),
+                    isUnavailable = layer.isUnavailable(),
                     infoBoxIsDisplayed = layer.infoIsDisplayed();
 
                 var cssClass = [];
@@ -384,6 +387,9 @@ define([
                 }
                 if (infoBoxIsDisplayed) {
                     cssClass.push('active');
+                }
+                if (isUnavailable) {
+                    cssClass.push('unavailable');
                 }
                 cssClass.push(layer.isFolder() ? 'parent-node' : 'leaf-node');
                 cssClass = cssClass.join(' ');

--- a/templates.html
+++ b/templates.html
@@ -37,18 +37,26 @@
 
         <span class="layer-icon">
         <% if (layer.isFolder()) { %>
-            <% if (isExpanded) { %>
+            <% if (layer.isUnavailable()) { %>
+                <i class="icon-right-dir"></i>
+            <% } else if (isExpanded) { %>
                 <i class="icon-down-dir"></i>
             <% } else { %>
                 <i class="icon-right-dir"></i>
             <% } %>
         <% } else { %>
-            <i class="icon-circle<% if (!isSelected) { %>-empty<% } %>"></i>
+            <% if (!layer.isUnavailable()) { %>
+                <i class="icon-circle<% if (!isSelected) { %>-empty<% } %>"></i>
+            <% } %>
         <% } %>
         </span>
 
         <span class="layer-name">
-            <%= layer.getDisplayName() %>
+            <% if (layer.isUnavailable()) { %>
+                <em>Service unavailable</em>
+            <% } else { %>
+                <%= layer.getDisplayName() %>
+            <% } %>
         </span>
 
         </a>


### PR DESCRIPTION
- If a service is unavailable, show an error message in
  place of the layer in the layer selector.
- Prevent users from selecting unavailable layers.
- Don't make requests for mal- or partially defined
  services. (Refs
  https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/582).
  This needed to be fixed here or else partially defined services (like
  Alabama) would show a service unavailable message.

![image](https://cloud.githubusercontent.com/assets/1042475/14443054/d8903312-000a-11e6-8f94-f1c4b728132a.png)

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/601
Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/582

**Testing instructions**
- Add the following section to the `sample_layers.json` and rename the file `layers.json`.

```
    {
        "displayName": "Bad Service",
        "server": {
            "type": "ags",
            "layerType": "dynamic",
            "url": "http://services.coastalresilience.org/arcgis/rest/services/New_Jersey/",
            "name": "Bad_Service"
        },
        "includeLayers": [
            {
                "name": "Boundaries",
                "displayName": "Boundaries",
                "includeLayers": [
                    {
                        "name": "Congressional Districts",
                        "description": "(Custom) This polygon layer delineates the US Congressional District boundaries in New Jersey, 2012 - 2022."
                    }
                ]
            }
        ]
    },
```
- Verify the service shows up as "Service unavailable" and that it cannot be selected.
