### PR TITLE
Update layer selector style so header is fixed.

### DIFF
--- a/draw_report/style.css
+++ b/draw_report/style.css
@@ -8,6 +8,13 @@
     padding: 12px;
 }
 
+.layer-selector2 .tab-report .report-intro {
+    overflow: auto;
+    position: absolute;
+    top: 0px;
+    bottom: 40px;
+}
+
 /* Display report layers as a normal list */
 .layer-selector2 .tab-report ul li ul {
     margin-left: 20px;
@@ -70,4 +77,14 @@
     width: 100%;
     height: 100%;
     background: rgba(255, 255, 255, 0.75) url(../spinner.gif) 50% 50% no-repeat;
+}
+
+.layer-selector2 .tab-report .results {
+    position: absolute;
+    right: 0;
+    left: 0;
+    bottom: 41px;
+    top: 43px;
+    overflow: auto;
+    padding: 0 10px;
 }

--- a/draw_report/templates.html
+++ b/draw_report/templates.html
@@ -1,4 +1,4 @@
-﻿<script type="text/template" id="plugin">
+<script type="text/template" id="plugin">
 <% if (reportData && reportData.length > 0) { %>
   <div class="result-header">
     <a href="javascript:;" class="start-drawing i18n" data-i18n="Redraw area of interest"
@@ -9,6 +9,7 @@
     <a href="javascript:;" class="button-download"><i class="icon-download"></i></a>
   </div>
 
+  <div class="results">
     <% _.each(reportData, function(item) { %>
       <h4><%- item.layer.getDisplayName() %></h4>
       <% if (item.reports.error) { %>
@@ -48,42 +49,44 @@
 
       <% } %>
     <% }) %>
+  </div>
 
   <% } else { %>
-    <p class="i18n" data-i18n="Draw and report is a way to view specific data by drawing a custom shape on the map. Your report will contain:">
-      Draw and report is a way to view specific data by drawing a custom
-      shape on the map. Your report will contain:
-    </p>
-
-    <% if (!layers.length) { %>
-      <p><em class="i18n" data-i18n="No layers have been selected yet">No layers have been selected yet.</em></p>
-
-    <% } else { %>
-      <ul>
-        <% _.each(layers, function(layer) { %>
-          <li>
-            <h4><%- layer.getDisplayName() %></h4>
-            <% if (layer.getReports().length > 0) { %>
-              <ul>
-                <% _.each(layer.getReports(), function(report) { %>
-                  <li><%- report.display %></li>
-                <% }) %>
-              </ul>
-            <% } else { %>
-              <p><em class="i18n" data-i18n="No reports have been configured for this layer">No reports have been configured for this layer.</em></p>
-            <% } %>
-          </li>
-        <% }) %>
-      </ul>
-
-      <p class="text-center">
-        <button class="start-drawing button radius i18n" data-i18n="Draw area of interest"
-            <%= (isDrawing ? 'disabled="disabled"' : '') %>>Draw area of interest</button>
-
-        <button class="cancel-drawing button radius i18n<%= (isDrawing ? '' : ' hidden') %>"
-            data-i18n="Cancel">Cancel</button>
+    <div class="report-intro">
+      <p class="i18n" data-i18n="Draw and report is a way to view specific data by drawing a custom shape on the map. Your report will contain:">
+        Draw and report is a way to view specific data by drawing a custom
+        shape on the map. Your report will contain:
       </p>
 
+      <% if (!layers.length) { %>
+        <p><em class="i18n" data-i18n="No layers have been selected yet">No layers have been selected yet.</em></p>
+
+      <% } else { %>
+        <ul>
+          <% _.each(layers, function(layer) { %>
+            <li>
+              <h4><%- layer.getDisplayName() %></h4>
+              <% if (layer.getReports().length > 0) { %>
+                <ul>
+                  <% _.each(layer.getReports(), function(report) { %>
+                    <li><%- report.display %></li>
+                  <% }) %>
+                </ul>
+              <% } else { %>
+                <p><em class="i18n" data-i18n="No reports have been configured for this layer">No reports have been configured for this layer.</em></p>
+              <% } %>
+            </li>
+          <% }) %>
+        </ul>
+
+        <p class="text-center">
+          <button class="start-drawing button radius i18n" data-i18n="Draw area of interest"
+              <%= (isDrawing ? 'disabled="disabled"' : '') %>>Draw area of interest</button>
+
+          <button class="cancel-drawing button radius i18n<%= (isDrawing ? '' : ' hidden') %>"
+              data-i18n="Cancel">Cancel</button>
+        </p>
+      </div>
     <% } %>
   <% } %>
   <div class="loading" <%= (isLoading ? 'style="display:block"' : '') %>></div>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,7 @@
 ﻿.x-body .layer-selector2 {
     color: #666;
+    height: 100%;
+    overflow: hidden;
 }
 
 .layer-selector2 ul li ul {
@@ -23,12 +25,23 @@
 
 .layer-selector2 .filter-container {
     padding: 6px 4px;
+    border-bottom: 1px solid #f8f8f8;
     }
     .layer-selector2 input.filter {
         width: 60%;
         display: inline;
         margin-right: 15px;
+        margin-bottom: 0;
     }
+
+.layer-selector2 .tree-container {
+    position: absolute;
+    right: 0;
+    left: 0;
+    bottom: 40px;
+    top: 44px;
+    overflow: auto;
+}
 
 .layer-selector2 .tree-container li {
     position: relative;
@@ -201,4 +214,5 @@
     }
     .layer-selector2 .tab-body.active {
         display: block;
+        height: 100%;
     }


### PR DESCRIPTION
- Add styles to make the layer selector controls/header fixed
  to the top of the plugin container. This is how the previous
  version of the layer selector behaved.

Thanks to @jfrankl for the help.

This is the same as https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/627

**Testing**
- Expand the layer tree in the layer control, and verify that when you scroll, the tabs and filter input stay at the top of the plugin window.
- Test the draw and report tab for the same behavior.

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/608
