### PR TITLE
Make metadata popup text black

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,10 @@
     margin-left: 0;
 }
 
+.layer-selector2 .info-box {
+    color: #000;
+}
+
 .layer-selector2 .tab-layers,
 .layer-selector2 .tab-report {
     position: relative;


### PR DESCRIPTION
Makes the text of the meta data popup black.

![screenshot 2016-04-28 at 3 46 00 pm](https://cloud.githubusercontent.com/assets/1014341/14899068/5f3486d4-0d58-11e6-9c1d-02d43321bbcf.png)

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/646
##### Testing

Is the text of the popup black?
- [x] yes
- [ ] no
