### PR TITLE
Draw and report updates.

### DIFF
--- a/draw_report/main.js
+++ b/draw_report/main.js
@@ -167,6 +167,15 @@ define(["dojo/_base/declare",
                 return this.reportData;
             },
 
+            getLayerReportCount: function() {
+                var activeLayers = this.getActiveLayers(),
+                    count = _.reduce(activeLayers, function(memo, layer) {
+                        return memo + layer.getReports().length;
+                    }, 0);
+
+                return count;
+            },
+
             setReportData: function(data) {
                 this.reportData = data;
             },
@@ -353,6 +362,7 @@ define(["dojo/_base/declare",
 
                 var html = this.pluginTmpl({
                     layers: this.getActiveLayers(),
+                    reportCount: this.getLayerReportCount(),
                     reportData: this.getReportData(),
                     isDrawing: !!this.isDrawing,
                     isLoading: !!this.isLoading

--- a/draw_report/style.css
+++ b/draw_report/style.css
@@ -60,6 +60,10 @@
     font-weight: normal;
 }
 
+.layer-selector2 .tab-report .button-container {
+    margin-top: 20px;
+}
+
 .layer-selector2 .tab-report .cancel-drawing {
     background-color: #cb2b2b;
     border-color: #8c1e1e;

--- a/draw_report/style.css
+++ b/draw_report/style.css
@@ -11,7 +11,7 @@
 .layer-selector2 .tab-report .report-intro {
     overflow: auto;
     position: absolute;
-    top: 0px;
+    top: 65px;
     bottom: 40px;
 }
 
@@ -61,7 +61,16 @@
 }
 
 .layer-selector2 .tab-report .button-container {
-    margin-top: 20px;
+    margin-bottom: 0px;
+}
+
+.layer-selector2 .tab-report .button-container .button {
+    width: 45%;
+    display: inline-block;
+}
+
+.layer-selector2 .tab-report .button-container .button.hidden {
+    display: none;
 }
 
 .layer-selector2 .tab-report .cancel-drawing {

--- a/draw_report/templates.html
+++ b/draw_report/templates.html
@@ -52,8 +52,8 @@
   </div>
 
   <% } else { %>
-    <div class="report-intro">
-      <% if (layers.length) { %>
+    <% if (layers.length) { %>
+      <div class="result-header">
         <p class="text-center button-container">
           <button class="start-drawing button radius i18n" data-i18n="Draw area of interest"
               <%= (isDrawing || !reportCount ? 'disabled="disabled"' : '') %>>Draw area of interest</button>
@@ -61,8 +61,10 @@
           <button class="cancel-drawing button radius i18n<%= (isDrawing ? '' : ' hidden') %>"
               data-i18n="Reset">Reset</button>
         </p>
-      <% } %>
+      </div>
+    <% } %>
 
+    <div class="report-intro">
       <p class="i18n" data-i18n="Draw and report is a way to view specific data by drawing a custom shape on the map. Your report will contain:">
         Draw and report is a way to view specific data by drawing a custom
         shape on the map. Your report will contain:

--- a/draw_report/templates.html
+++ b/draw_report/templates.html
@@ -53,6 +53,16 @@
 
   <% } else { %>
     <div class="report-intro">
+      <% if (layers.length) { %>
+        <p class="text-center button-container">
+          <button class="start-drawing button radius i18n" data-i18n="Draw area of interest"
+              <%= (isDrawing || !reportCount ? 'disabled="disabled"' : '') %>>Draw area of interest</button>
+
+          <button class="cancel-drawing button radius i18n<%= (isDrawing ? '' : ' hidden') %>"
+              data-i18n="Reset">Reset</button>
+        </p>
+      <% } %>
+
       <p class="i18n" data-i18n="Draw and report is a way to view specific data by drawing a custom shape on the map. Your report will contain:">
         Draw and report is a way to view specific data by drawing a custom
         shape on the map. Your report will contain:
@@ -60,7 +70,6 @@
 
       <% if (!layers.length) { %>
         <p><em class="i18n" data-i18n="No layers have been selected yet">No layers have been selected yet.</em></p>
-
       <% } else { %>
         <ul>
           <% _.each(layers, function(layer) { %>
@@ -78,14 +87,6 @@
             </li>
           <% }) %>
         </ul>
-
-        <p class="text-center">
-          <button class="start-drawing button radius i18n" data-i18n="Draw area of interest"
-              <%= (isDrawing ? 'disabled="disabled"' : '') %>>Draw area of interest</button>
-
-          <button class="cancel-drawing button radius i18n<%= (isDrawing ? '' : ' hidden') %>"
-              data-i18n="Cancel">Cancel</button>
-        </p>
       </div>
     <% } %>
   <% } %>

--- a/locales/en.json
+++ b/locales/en.json
@@ -18,5 +18,5 @@
     "Click to continue drawing": "Click to continue drawing",
     "Double-click to complete": "Double-click to complete",
     "Unknown": "Unknown",
-    "Cancel": "Cancel"
+    "Reset": "Reset"
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -18,5 +18,5 @@
     "Click to continue drawing": "Haga clic para seguir dibujando",
     "Double-click to complete": "Haga doble clic para completar",
     "Unknown": "Desconocido",
-    "Cancel": "Cancelar"
+    "Reset": "Cancelar"
 }


### PR DESCRIPTION
- Move draw and cancel buttons to the top of the plugin. 
- Change text of cancel button to "Reset", and update translation
  files accordingly.
- If none of the active layers have configured reports, disable
  the draw button. 

**Testing instructions**
- Verify the changes in the referenced issues are satisfied by this PR.

Button at top, disabled because the active layers don't have reports.

![image](https://cloud.githubusercontent.com/assets/1042475/14903297/27cc32da-0d6e-11e6-8b1c-1d5cae8d63fc.png)

Renamed cancel button

![image](https://cloud.githubusercontent.com/assets/1042475/14903307/35891faa-0d6e-11e6-8453-69348e13eb10.png)

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/640
Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/641
Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/642
