### PR TITLE
Translate error text if layer has no reports.

### DIFF
--- a/draw_report/main.js
+++ b/draw_report/main.js
@@ -261,7 +261,7 @@ define(["dojo/_base/declare",
 
                 if (!reportLayers.length) {
                     defer.resolve({
-                        error: 'No reports have been configured for this layer.'
+                        error: i18next.t('No reports have been configured for this layer')
                     });
                     return defer;
                 }


### PR DESCRIPTION
- Wrap text in translation function.
- Drop period from error message so that it matches the key
  in the translation file, which doesn't have a period.

**Testing**
- Switch the framework language to `es`.
- Add some layers that don't have reports.
- Draw a report area.
- The error message for each layer should be translated.

![image](https://cloud.githubusercontent.com/assets/1042475/14922624/a41cba24-0e06-11e6-82b8-a3d520b770b9.png)

Connects to #22
