### PR TITLE
Fix overflow when plugin is not resizable

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,5 +3,8 @@
         "plugins/regional-planning/fontello-8ae227d1/css/layer-selector-v2.css",
         "plugins/regional-planning/style.css",
         "plugins/regional-planning/draw_report/style.css"
-    ]
+    ],
+    "use": {
+        "tv4": { "attach": "tv4" }
+    }
 }

--- a/style.css
+++ b/style.css
@@ -220,3 +220,8 @@
         display: block;
         height: 100%;
     }
+
+/* See #29 */
+.content .plugin-container-outer .plugin-container {
+    padding-bottom: 28px;
+}

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-﻿.x-body .layer-selector2 {
+.layer-selector2 {
     color: #666;
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
- When resizable is set to false in overrides.json, a style rule
  for resizable containers was not applied. This resulted in the
  layer list container overflowing outside of the plugin container.
  Here, we add the style rule that was previously only being applied
  to resizable plugins. We don't add it to the framework to prevent
  any undesirable effects on other plugins.

**Testing**
- Toggle the resizability of the plugin and verify that the layer list doesn't overflow outside of the container.

![image](https://cloud.githubusercontent.com/assets/1042475/15295346/13b6d400-1b5e-11e6-9313-21faed660ee8.png)

Connects to #29
