### PR TITLE
Import LayerNode module in main

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,7 +32,8 @@ define([
         "./draw_report/main",
         "./State",
         "./Config",
-        "./Tree"
+        "./Tree",
+        "./LayerNode",
     ],
     function(declare,
              Deferred,
@@ -52,7 +53,8 @@ define([
              DrawAndReport,
              State,
              Config,
-             Tree) {
+             Tree,
+             LayerNode) {
         "use strict";
 
         var overrides = JSON.parse(overridesJson);


### PR DESCRIPTION
- A method on LayerNode is used in restoreSelectedLayers method
  to restore from saved state. Without importing LayerNode, this
  method is not available.

I believe this addresses all of the issues listed in #28.

**Testing**
- Load the framework and activate some layers.
- Get the save and share URL and go to the saved site.
- Verify the regional-planning plugin opens with the correct layers activated, the layers are added to the map, and there are no console errors.

Connects to #28
