### PR TITLE
Attach tv4 `use!`

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -3,5 +3,8 @@
         "plugins/regional-planning/fontello-8ae227d1/css/layer-selector-v2.css",
         "plugins/regional-planning/style.css",
         "plugins/regional-planning/draw_report/style.css"
-    ]
+    ],
+    "use": {
+        "tv4": { "attach": "tv4" }
+    }
 }


### PR DESCRIPTION
Since regional-planning is the only plugin to actually use tv4, it needs
to attach it to the use! config.

Connects #32

Testing:
@caseypt - should resolve the tv4 error from  https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/652
