### PR TITLE
Remove reference to Ext.js class

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-﻿.x-body .layer-selector2 {
+.layer-selector2 {
     color: #666;
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
- Ext.js is no longer included in the framework. Referencing the
  Ext class results in the layer list not showing up.

**Testing**
- Check that the list of layers is now visible.

![image](https://cloud.githubusercontent.com/assets/1042475/15329014/25321f56-1c25-11e6-99df-e3cc38b6631e.png)

Connects to #35
