### PR TITLE
Fix overflow when plugin is not resizable

### DIFF
--- a/style.css
+++ b/style.css
@@ -220,3 +220,8 @@
         display: block;
         height: 100%;
     }
+
+/* See #29 */
+.content .plugin-container-outer .plugin-container {
+    padding-bottom: 28px;
+}


### PR DESCRIPTION
- When resizable is set to false in overrides.json, a style rule
  for resizable containers was not applied. This resulted in the
  layer list container overflowing outside of the plugin container.
  Here, we add the style rule that was previously only being applied
  to resizable plugins. We don't add it to the framework to prevent
  any undesirable effects on other plugins.

Connects to #29
