### PR TITLE
Fix `includeAllLayers` property for root service nodes

### DIFF
--- a/AgsService.js
+++ b/AgsService.js
@@ -77,6 +77,18 @@ define([
                     };
                 }
 
+                // Return artificial service data to support the
+                // `includeAllLayers` property for root nodes.
+                if (layer.isRootNode()) {
+                    var subLayers = _.filter(serviceData.layers, {
+                        parentLayerId: -1
+                    });
+                    return {
+                        id: -1,
+                        subLayerIds: _.pluck(subLayers, 'id')
+                    };
+                }
+
                 return _.find(serviceData.layers, function(serviceLayer) {
                     if (layer.getName() === serviceLayer.name) {
                         // Compare not only the name, but the structure as well.

--- a/Config.js
+++ b/Config.js
@@ -21,7 +21,9 @@
             constructor: function () {
                 var rawNodes = this.parse(layerSourcesJson),
                     layers = _.map(rawNodes, function(node) {
-                        return LayerNode.fromJS(node);
+                        return LayerNode.fromJS(_.assign({}, node, {
+                            isRootNode: true
+                        }));
                     });
                 this.tree = new Tree(layers);
             },

--- a/LayerNode.js
+++ b/LayerNode.js
@@ -230,6 +230,10 @@ define([
 
             isUnavailable: function() {
                 return !!this.node.isUnavailable;
+            },
+
+            isRootNode: function() {
+                return this.node.isRootNode;
             }
         });
 

--- a/Tree.js
+++ b/Tree.js
@@ -63,6 +63,12 @@ define([
                     layerData = _.assign({}, serviceLayer || {}, layerDetails || {}),
                     layerId = this.createLayerId(parent, layerData),
                     node = _.assign(layerData, {
+                        // Set `includeAllLayers` to true for dynamically
+                        // loaded service nodes that contain subLayers.
+                        // Otherwise, the tree will render group/folder
+                        // layers as leaf nodes, and child layers will
+                        // be ignored.
+                        includeAllLayers: !!serviceLayer.subLayerIds,
                         isSelected: state.isSelected(layerId),
                         isExpanded: state.isExpanded(layerId),
                         infoIsDisplayed: state.infoIsDisplayed(layerId),

--- a/WmsService.js
+++ b/WmsService.js
@@ -81,6 +81,24 @@ define([
 
                 if (!serviceData || !layer) {
                     return null;
+                } else if (serviceData instanceof Error) {
+                    // If the response from the server was an
+                    // error, the service is unavailable.
+                    return {
+                        isUnavailable: true
+                    };
+                }
+
+                // Return artificial service data to support the
+                // `includeAllLayers` property for root nodes.
+                if (layer.isRootNode()) {
+                    var subLayers = _.filter(serviceData.layers, {
+                        parentLayerId: -1
+                    });
+                    return {
+                        id: -1,
+                        subLayerIds: _.pluck(subLayers, 'id')
+                    };
                 }
 
                 return _.find(serviceData.layers, function(serviceLayer) {


### PR DESCRIPTION
The `includeAllLayers` property was always intended to work for both
service layers and service root nodes but it was never thoroughly
tested.

Since AGS does not define a root node for map services, we need to
produce an artificial root node.

---

This is an experimental feature which needs more testing, but the upshot is that you should be able dynamically load all layers for a service with this layers.json configuration:

```
"displayName": "Coastal Resilience (NJ)",
"name": "New_Jersey",
"includeAllLayers": true,
"server": {
    "type": "ags",
    "layerType": "dynamic",
    "url": "http://services.coastalresilience.org/arcgis/rest/services/New_Jersey/",
    "name": "New_Jersey"
},
```

![image](https://cloud.githubusercontent.com/assets/43062/18175431/4011dab4-703f-11e6-9e29-552d4ab24248.png)

Connects #49 
