### PR TITLE
Fix UI issues with "i" icon and layer tools menu icon.

### DIFF
--- a/State.js
+++ b/State.js
@@ -16,7 +16,7 @@ define([
                     expandedLayers: [],
                     // List of objects as { layerId: opacityValue }.
                     layerOpacity: [],
-                    // Layer id that infobox is display for.
+                    // Layer id that infobox is displayed for.
                     infoBoxLayerId: null
                 });
             },

--- a/main.js
+++ b/main.js
@@ -668,7 +668,6 @@ define([
                 this.clearActiveStateForLayerTools(selector);
                 $(el).find('i').addClass('active');
                 $(el).closest('[data-layer-id]').addClass('active');
-                this.rebuildTree();
             },
 
             clearActiveStateForLayerTools: function(selector) {
@@ -677,7 +676,6 @@ define([
 
                 $el.removeClass('active');
                 $el.closest('[data-layer-id]').removeClass('active');
-                this.rebuildTree();
             },
 
             // Rebuild tree from scratch.

--- a/main.js
+++ b/main.js
@@ -143,7 +143,6 @@ define([
                 $('body')
                     .on('click', '#' + this.layerMenuId + ' a.download', function() {
                         var layerId = self.getClosestLayerId(this);
-                        console.log('Download', layerId);
                         self.destroyLayerMenu();
                     })
                     .on('click', '#' + this.layerMenuId + ' a.zoom', function() {

--- a/main.js
+++ b/main.js
@@ -601,6 +601,7 @@ define([
             hideLayerInfo: function() {
                 $(this.container).find('.info-box-container').empty();
                 this.state = this.state.clearInfoBoxLayerId();
+                this.rebuildTree();
             },
 
             toggleLayer: function(layer) {


### PR DESCRIPTION
Fixes issues with layer icon highlight state. See commit messages for details.

**Testing**
- Activate the Regional Planning plugin.
- Hover over a layer and click the "i" icon to open the layer info box.
- When you hover over other layers, the "i" icon (as well as the layer row itself) should stay highlighted on the initial layer you clicked.
- When you close the info box, the "i" icon that was previously highlighted should become unhighlighted.
- On any layer, click the layer tools menu icon (`...`). 
- The layer tools menu should open and the `...` icon should stay highlighted and visible.

Connects to #43 
