### PR TITLE
Show info button for parent nodes

### DIFF
--- a/AgsService.js
+++ b/AgsService.js
@@ -33,12 +33,12 @@ define([
                 // If service information is only partially
                 // defined or the config is bad for this
                 // service, don't bother getting the data
-                // because it the response is an error.
+                // because the response will be an error.
                 if (serviceUrl.match(/undefined/) === null) {
                     return ajaxUtil.get(this.getServiceUrl());
                 }
 
-                return null;
+                return {};
             },
 
             // Return a promise with service layer data.

--- a/sample_layers.json
+++ b/sample_layers.json
@@ -1,6 +1,7 @@
 [
     {
         "displayName": "Coastal Resilience (NJ)",
+        "description": "New Jersey Layers",
         "server": {
             "type": "ags",
             "layerType": "dynamic",
@@ -196,6 +197,21 @@
         },
         "includeLayers": [
             { "name": "Inundation Depth " }
+        ]
+    },
+    {
+        "name": "St Vincent and the Grenadines",
+        "server": {
+            "type": "ags",
+            "layerType": "dynamic",
+            "url": "http://dev.services2.coastalresilience.org/arcgis/rest/services/GSVG",
+            "name": "GSVG"
+        },
+        "includeLayers": [
+             {
+                 "name": "St Vincent and the Grenadines",
+                 "includeAllLayers": true
+             }
         ]
     }
 ]

--- a/style.css
+++ b/style.css
@@ -72,7 +72,9 @@
         background: #f5f5f5;
     }
     .layer-selector2 .tree-container li.leaf-node .layer-tools i:hover,
-    .layer-selector2 .tree-container li.leaf-node .layer-tools i.active {
+    .layer-selector2 .tree-container li.leaf-node .layer-tools i.active,
+    .layer-selector2 .tree-container li.parent-node .layer-tools i:hover,
+    .layer-selector2 .tree-container li.parent-node .layer-tools i.active {
         color: #23618c;
     }
     .layer-selector2 .tree-container li.leaf-node.selected > a,
@@ -92,7 +94,9 @@
             width: auto;
         }
         .layer-selector2 .tree-container li.leaf-node:hover > .layer-tools,
-        .layer-selector2 .tree-container li.leaf-node.active > .layer-tools {
+        .layer-selector2 .tree-container li.leaf-node.active > .layer-tools,
+        .layer-selector2 .tree-container li.parent-node:hover > .layer-tools,
+        .layer-selector2 .tree-container li.parent-node.active > .layer-tools {
             display: block;
         }
 

--- a/templates.html
+++ b/templates.html
@@ -80,7 +80,13 @@
         <div class="body">
             <div class="description">
                 <div class="info-label"><%= layer.getDisplayName() %></div>
-                <div class="info-value"><%= layer.getDescription() %></div>
+                <div class="info-value">
+                    <% if (layer.getDescription() === '') { %>
+                        <em>No description or metadata available for this layer.</em>
+                    <% } else { %>
+                        <%= layer.getDescription() %>
+                    <% } %>
+                </div>
             </div>
         </div>
     </div>

--- a/templates.html
+++ b/templates.html
@@ -61,12 +61,12 @@
 
         </a>
 
-        <% if (!layer.isFolder()) { %>
         <div class="layer-tools">
             <a href="javascript:;" class="info"><i class="icon-info-circled <% if (infoBoxIsDisplayed) { %> active <% } %>"></i></a>
-            <a href="javascript:;" class="more"><i class="icon-ellipsis"></i></a>
+            <% if (!layer.isFolder()) { %>
+                <a href="javascript:;" class="more"><i class="icon-ellipsis"></i></a>
+            <% } %>
         </div>
-        <% } %>
 
     <% if (layer.isFolder() && isExpanded) { %>
         <%= _.map(layer.getChildren(), renderLayer).join('') %>


### PR DESCRIPTION
Adjust the style and layer node template so that the info button is shown
for parent nodes. Some layer group parents have their own descriptions.

Update the sample configuration file with a service that has a layer group
with a description and to show that top-level layers can also have a
description.

**Testing**
- Copy `sample_layers.json` as `layers.json`.
- Run the site and activate the `regional-planning` plugin.
- Verify that the layer info icon shows up on all layers now.
- Click the "Coastal Resilience (NJ)" layer info icon. The info window should open with a short description from `layers.json` and the layer info icon should remain highlighted.
- Click the info window. The layer info icon for the previously active layer should no longer be highlighted.
- Expand the `Grenada` layers and click the layer info icon for the "Inundation Scenarios" layer, which is a group layer parent. The info window should open with the description of the group from the server.

Connects to #50
