### PR TITLE
Use layer id to disamgibuate layers

### DIFF
--- a/AgsService.js
+++ b/AgsService.js
@@ -91,6 +91,14 @@ define([
 
                 return _.find(serviceData.layers, function(serviceLayer) {
                     if (layer.getName() === serviceLayer.name) {
+                        // If an id has been provided in the config, we only need to
+                        // compare it to the id in the service data to find the correct layer.
+                        // At this point, layer.getServiceId() will return undefined or
+                        // the id from the config.
+                        if (layer.getServiceId() && layer.getServiceId() !== serviceLayer.id) {
+                            return false;
+                        }
+
                         // Compare not only the name, but the structure as well.
                         // Protects against an edge case where a map service
                         // contains a parent and child layer with the same name.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The `regional-planning` plugin is an updated version of the [map-tree](https://g
 
 The easiest way to see how to configure the plugin is to take a look at [sample_layers.json](https://github.com/CoastalResilienceNetwork/regional-planning/blob/master/sample_layers.json). This configuration file exercises all of the of plugin's functionality. It initially started as updated version of the map-tree configuration for the [New Jersey region](https://github.com/CoastalResilienceNetwork/newjersey-region/blob/master/plugins/layer_selector/layers.json), but grew to test out more functionality.
 
-The biggest difference between the configuration of the `map-tree` plugin and the `regional-planning` plugin is that **layers are identified by name and not id**. This was done so that layers could be reordered in the map service without having to update the layer configuration. However, if the name of the layer is updated in the map service, you must also update the configuration for any region using that layer. Also, layers with duplicate names will cause problems with this plugin and should be avoided.
+The biggest difference between the configuration of the `map-tree` plugin and the `regional-planning` plugin is that **layers are identified by name and not id**. This was done so that layers could be reordered in the map service without having to update the layer configuration. However, if the name of the layer is updated in the map service, you must also update the configuration for any region using that layer. If there are layers with duplicate names within the same map service, you can use layer ids to disambiguate layers.
 
 ##### Top-level layer object
 
@@ -27,6 +27,7 @@ Top-level layers are the first thing you will specify in the configuration. They
 The layer object is the core configuration object used in the config.
 
 - **name** - The name of the layer. This must match the name of the layer in the map service. **For the top-level layers that function as folders, no value is required for `name`**
+- **id** - The id of the layer. **This property is only required to disambiguate layers when there are multiple layers in a service with the same name**
 - **displayName** - The name that will be displayed in the plugin UI.
 - **description** - A custom description for the layer that will be shown in the plugin UI. If this is not specified, the description stored with the layer in the map service will be used.
 - **downloadUrl** - URL to download the layer. This can be any URL, but should be a URL to a zip file, shapefile, or some other file related to the layer.

--- a/schema.js
+++ b/schema.js
@@ -20,6 +20,7 @@
             additionalProperties: false,
             properties: {
                 name: { type: 'string' },
+                id: { type: 'number' },
                 displayName: { type: 'string' },
                 description: { type: 'string' },
                 availableInRegions: { type: 'array', items: { type: 'string' } },


### PR DESCRIPTION
If there are layers within the same map service that have the same name,
allow developers to specify the layer id in the config to disambiguate
these layers.

Update the documentation accordingly.

**Testing**
- Update `layers.json` with the following:

``` json
[
    {
        "name": "Grenada",
        "server": {
            "type": "ags",
            "layerType": "dynamic",
            "url": "http://dev.services2.coastalresilience.org/arcgis/rest/services/GSVG",
            "name": "GSVG"
        },
        "includeLayers": [
            {
                "id": 1,
                "name": "Inundation Scenarios",
                "includeAllLayers": true
            },
            {
                "name": "Ecological",
                "id": 9,
                "includeAllLayers": true
            },
            {
                "id": 19,
                "name": "Social and Economic",
                "includeLayers": [
                    {
                        "id": 20,
                        "name": "Critical Infrastructure",
                        "includeAllLayers": true
                    }
                ]
            }
        ]
    },
    {
        "name": "St Vincent and the Grenadines",
        "server": {
            "type": "ags",
            "layerType": "dynamic",
            "url": "http://dev.services2.coastalresilience.org/arcgis/rest/services/GSVG",
            "name": "GSVG"
        },
        "includeLayers": [
            {
                "id": 115,
                "name": "Inundation Scenarios",
                "includeAllLayers": true
            },
            {
                "id": 123,
                "name": "Ecological",
                "includeAllLayers": true
            },
            {
                "id": 133,
                "name": "Social and Economic",
                "includeLayers": [
                    {
                        "id": 134,
                        "name": "Critical Infrastructure",
                        "includeAllLayers": true
                    }
                ]
            }
        ]
    }
]
```
- Toggle the layers, and verify that the duplicate layers in each group are in fact turning on and off different layers.

![image](https://cloud.githubusercontent.com/assets/1042475/18888418/39f8a43c-84c6-11e6-85d0-d856282b732d.png)

Connects to #51
