### PR TITLE
WIP: Cut overrides.json file and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,15 +86,3 @@ The layers in this configuration will be rendered like so in the UI:
   > Layer A
     * ## Layer B
 ```
-
-### Overriding the plugin UI
-
-Components of the UI can be overridden by creating a `overrides.json` file. There is a sample available [here](https://github.com/CoastalResilienceNetwork/regional-planning/blob/master/overrides.json). The override configuration settings are detailed below.
-
-- **name** - The name that is displayed in the plugin title bar. The default is "Regional Planning"
-- **description** - The text that is displayed when users hover on the plugin button. The default is "Configure and control layers to be overlayed on the base map".
-- **height** - The initial height of the plugin in pixels. The default is 400.
-- **width** - The initial width of the plugin in pixels. The default is 300.
-- **resizable** - Determines whether or not the user can resize the plugin window. The default is `true`.
-- **hasCustomPrint** - Determines whether or not the plugin has a custom print layout. The default is `true`.
-- **infoGraphic** - An image or HTML snippet to use as the infographic for the plugin introduction. The default is that there is no infographic.

--- a/main.js
+++ b/main.js
@@ -20,7 +20,6 @@ define([
         "jquery",
         "underscore",
         "dojo/text!./templates.html",
-        "dojo/text!./overrides.json",
         "esri/layers/FeatureLayer",
         "esri/layers/ArcGISDynamicMapServiceLayer",
         "esri/layers/ArcGISTiledMapServiceLayer",
@@ -41,7 +40,6 @@ define([
              $,
              _,
              templates,
-             overridesJson,
              FeatureLayer,
              ArcGISDynamicMapServiceLayer,
              ArcGISTiledMapServiceLayer,
@@ -57,15 +55,12 @@ define([
              LayerNode) {
         "use strict";
 
-        var overrides = JSON.parse(overridesJson);
         return declare(PluginBase, {
-            toolbarName: overrides.name || "Regional Planning",
-            fullName: overrides.description || "Configure and control layers to be overlayed on the base map.",
-            width: overrides.width || 300,
-            height: overrides.height || 400,
-            resizable: _.isUndefined(overrides.resizable) ? true : overrides.resizable,
-            hasCustomPrint: _.isUndefined(overrides.hasCustomPrint) ? true : overrides.hasCustomPrint,
-            infoGraphic: _.isUndefined(overrides.infoGraphic) ? undefined : overrides.infoGraphic,
+            toolbarName: "Regional Planning",
+            fullName: "Configure and control layers to be overlayed on the base map.",
+            size: 'small',
+            hasCustomPrint: true,
+            infoGraphic: undefined,
             toolbarType: "sidebar",
             allowIdentifyWhenActive: true,
 

--- a/overrides.json
+++ b/overrides.json
@@ -1,8 +1,0 @@
-{
-    "name": "Regional Planning",
-    "description": "Configure and control layers to be overlayed on the base map.",
-    "height": 400,
-    "width": 300,
-    "resizable": true,
-    "hasCustomPrint": true
-}


### PR DESCRIPTION
- remove `overrides.json` file
- drop overrides section from README
- cut overrides uses from `main.js`
- drop `height` and `resizable` settings from `main.js`

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/711
