### PR TITLE
Adjust `overrides.json` settings to reflect prototype options

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ Components of the UI can be overridden by creating a `overrides.json` file. Ther
 
 - **name** - The name that is displayed in the plugin title bar. The default is "Regional Planning"
 - **description** - The text that is displayed when users hover on the plugin button. The default is "Configure and control layers to be overlayed on the base map".
-- **height** - The initial height of the plugin in pixels. The default is 400.
+- **size** - The size of the plugin: `'small'`, `'large'`, or `'custom'`. The default is `'small'`. If `'custom'` is selected the plugin's width will be set from the `'width'` property.
 - **width** - The initial width of the plugin in pixels. The default is 300.
-- **resizable** - Determines whether or not the user can resize the plugin window. The default is `true`.
 - **hasCustomPrint** - Determines whether or not the plugin has a custom print layout. The default is `true`.
 - **infoGraphic** - An image or HTML snippet to use as the infographic for the plugin introduction. The default is that there is no infographic.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,6 @@ Components of the UI can be overridden by creating a `overrides.json` file. Ther
 - **name** - The name that is displayed in the plugin title bar. The default is "Regional Planning"
 - **description** - The text that is displayed when users hover on the plugin button. The default is "Configure and control layers to be overlayed on the base map".
 - **size** - The size of the plugin: `'small'`, `'large'`, or `'custom'`. The default is `'small'`. If `'custom'` is selected the plugin's width will be set from the `'width'` property.
-- **width** - The initial width of the plugin in pixels. The default is 300.
+- **width** - The width of the plugin in pixels. Required if `size` is set to `'custom'`; ignored otherwise.
 - **hasCustomPrint** - Determines whether or not the plugin has a custom print layout. The default is `true`.
 - **infoGraphic** - An image or HTML snippet to use as the infographic for the plugin introduction. The default is that there is no infographic.

--- a/main.js
+++ b/main.js
@@ -61,9 +61,8 @@ define([
         return declare(PluginBase, {
             toolbarName: overrides.name || "Regional Planning",
             fullName: overrides.description || "Configure and control layers to be overlayed on the base map.",
+            size: overrides.size || 'small',
             width: overrides.width || 300,
-            height: overrides.height || 400,
-            resizable: _.isUndefined(overrides.resizable) ? true : overrides.resizable,
             hasCustomPrint: _.isUndefined(overrides.hasCustomPrint) ? true : overrides.hasCustomPrint,
             infoGraphic: _.isUndefined(overrides.infoGraphic) ? undefined : overrides.infoGraphic,
             toolbarType: "sidebar",

--- a/overrides.json
+++ b/overrides.json
@@ -1,8 +1,6 @@
 {
     "name": "Regional Planning",
     "description": "Configure and control layers to be overlayed on the base map.",
-    "height": 400,
-    "width": 300,
-    "resizable": true,
+    "size": "small",
     "hasCustomPrint": true
 }


### PR DESCRIPTION
This PR updates the pugin's `overrides.json` file (and related settings and documentation) to remove the `height` and `resizable` options which are no longer applicable and to note the availability & use of the new `size` option.

In addition to removing the `height` and `resizable` options from the overrides file, I also removed them from `main.js`, and the project README. I included and documented the new `size` option, and noted that the `width` option applies when `size` is set to `'custom'`.

**Testing**
- get this branch of the plugin
- edit the `overrides.json` file to change the size to `'large'` and to add `"width": 1000,` as a property
- rebuild the Geosite Framework project in Visual Studio
- view the project in the web browser and verify that the plugin's size is large (but not 1000). You can check this by finding the `regional-planning` sidebar in the elements tab, then verifying that it has a class of `sidebar-width-large`:

![screen shot 2016-10-27 at 12 44 25 pm](https://cloud.githubusercontent.com/assets/4165523/19776709/3712a512-9c43-11e6-82e9-ca24454c8427.png)
- edit `overrides.json` again and change the size from `'large'` to `'custom'`
- rebuild the app and view it again in the browser
- verify that the size is now 1000 px and that the `regional-planning` sidebar now has a class of `sidebar-width-custom`
- verify that everything else still works as it should and that there aren't any non-ArcGIS errors in the console

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/711
