### PR TITLE
Remove UL browser styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,6 +60,12 @@
     overflow: auto;
 }
 
+.layer-selector2 .tree-container ul {
+    margin: 0;
+    list-style-type: none;
+    padding: 0;
+}
+
 .layer-selector2 .tree-container li {
     position: relative;
     color: #222;


### PR DESCRIPTION
The default browser styling is not desirable for this element.

Before:
![image](https://cloud.githubusercontent.com/assets/1042475/20366742/725f5390-ac1a-11e6-8d8d-b23f5c06c658.png)


After:
![image](https://cloud.githubusercontent.com/assets/1042475/20366722/5f319896-ac1a-11e6-8834-58f16a10580c.png)
