### PR TITLE
Update stylesheet to ensure the layer menu shows

### DIFF
--- a/style.css
+++ b/style.css
@@ -178,7 +178,7 @@
         background: #bebebe;
         color: #414141;
         width: 140px;
-        z-index: 1000;
+        z-index: 2000;
     }
     .layer-selector2-layer-menu:after {
         width: 0;


### PR DESCRIPTION
This ensures that the "Zoom to Extent" and any other items in the layer menu are visible.

To test:
* clone this branch and bounce the Geosite framework app, if necessary
* click on a few menu toggle controls in the plugin and check that the menu is visible
![download](https://cloud.githubusercontent.com/assets/18290666/21397409/a725798e-c771-11e6-966f-15b596c94a4b.png)


It's worth mentioning that this PR directly addresses the specific bug from the connected issue, but in fixing that I noticed a few other problems with this control:
* I would expect the element to be positioned above the "parent" row, so both are visible
* the control seems narrow
* the control "sticks" until it or the map is clicked, even if the plugin is deactivated or exited
![download 1](https://cloud.githubusercontent.com/assets/18290666/21397459/d08b913c-c771-11e6-9706-45d523d3c796.png)



Connects #67 