### PR TITLE
Enable showing layer options on iOS Safari

### DIFF
--- a/draw_report/style.css
+++ b/draw_report/style.css
@@ -101,3 +101,7 @@
     overflow: auto;
     padding: 0 10px;
 }
+
+.layer-selector2 .tree-container {
+    position: revert !important;
+}


### PR DESCRIPTION
## Overview

Due to inheriting a `position: absolute` rule, the layer options list in this plugin would not show up in iOS Safari. This PR adds a `position: revert` rule which leads them to display properly on iOS Safari, while keeping them also working in Chrome, Safari, IE11, and desktop browsers.

## Testing
 *  get this branch of the plugin, then launch the framework in VS and visit in the browser. Verify that the plugin's layer options list still appears and that they can all still be clicked & enabled
 * using an iPad, visit the site served from your local and verify that the layer options are also visible and working there

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/771