### PR TITLE
Update style to match style guide

### DIFF
--- a/main.js
+++ b/main.js
@@ -98,8 +98,8 @@ define([
             bindTabEvents: function() {
                 var self = this,
                     $el = $(this.container);
-                $el.on('click', 'dl.tabs a', function() {
-                    var tab = $(this).attr('data-tab');
+                $el.on('click', 'ul.nav-tabs a', function() {
+                    var tab = $(this).data('tab');
                     self.state = self.state.setTab(tab);
                     self.render();
                 });
@@ -357,8 +357,8 @@ define([
                     tab: this.state.getTab()
                 }));
 
-                $el.find('.tab-layers').append($(this.layersPluginTmpl()));
-                $el.find('.tab-report').append(this.drawReport.render());
+                $el.find('#layer-selector-tab-layers').append($(this.layersPluginTmpl()));
+                $el.find('#layer-selector-tab-report').append(this.drawReport.render());
 
                 $(this.container).empty().append($el);
                 this.renderLayerSelector();
@@ -478,11 +478,11 @@ define([
             },
 
             showSpinner: function() {
-                $(this.container).find('.tab-layers .loading').show();
+                $(this.container).find('#layer-selector-tab-layers .loading').show();
             },
 
             hideSpinner: function() {
-                $(this.container).find('.tab-layers .loading').hide();
+                $(this.container).find('#layer-selector-tab-layers .loading').hide();
             },
 
             // Fetch all map services so that on-demand layers are available

--- a/sample_layers.json
+++ b/sample_layers.json
@@ -134,7 +134,7 @@
         "server": {
             "type": "ags",
             "layerType": "dynamic",
-            "url": "http://dev.services2.coastalresilience.org/arcgis/rest/services/Gulf_of_Mexico/",
+            "url": "http://services.coastalresilience.org/arcgis/rest/services/Gulf_of_Mexico/",
             "name": "Alabama"
         },
         "includeLayers": [
@@ -204,7 +204,7 @@
         "server": {
             "type": "ags",
             "layerType": "dynamic",
-            "url": "http://dev.services2.coastalresilience.org/arcgis/rest/services/GSVG",
+            "url": "http://services.coastalresilience.org/arcgis/rest/services/GSVG",
             "name": "GSVG"
         },
         "includeLayers": [

--- a/style.css
+++ b/style.css
@@ -1,20 +1,11 @@
-/* Foundation style */
-/* Tabs ---------------------- */
-.tabs { list-style: none; border-bottom: solid 1px #e6e6e6; display: block; height: 40px; padding: 0; margin-bottom: 20px; }
-.tabs.contained { margin-bottom: 0; margin-left: 0; }
-.tabs dt, .tabs li.section-title { color: #b3b3b3; cursor: default; display: block; float: left; font-size: 12px; height: 40px; line-height: 40px; padding: 0; padding-right: 9px; padding-left: 20px; font-weight: normal; width: auto; text-transform: uppercase; }
-.tabs dt:first-child, .tabs li.section-title:first-child { padding: 0; padding-right: 9px; }
-.tabs dd, .tabs li { display: block; float: left; padding: 0; margin: 0; }
-.tabs dd a, .tabs li a { color: #6f6f6f; display: block; font-size: 14px; height: 40px; line-height: 40px; padding: 0px 23.8px; }
-.tabs dd a:focus, .tabs li a:focus { font-weight: bold; color: #2ba6cb; }
-.tabs dd.active, .tabs li.active { border-top: 3px solid #2ba6cb; margin-top: -3px; }
-.tabs dd.active a, .tabs li.active a { cursor: default; color: #3c3c3c; background: #fff; border-left: 1px solid #e6e6e6; border-right: 1px solid #e6e6e6; font-weight: bold; }
-.tabs dd:first-child, .tabs li:first-child { margin-left: 0; }
-
 .layer-selector2 {
     color: #666;
     height: 100%;
     overflow: hidden;
+}
+
+.layer-selector2 .tab-content {
+    height: 100%;
 }
 
 .layer-selector2 ul li ul {
@@ -25,12 +16,20 @@
     color: #000;
 }
 
-.layer-selector2 .tab-layers,
-.layer-selector2 .tab-report {
+.layer-selector2 .tab-body {
     position: relative;
 }
 
-.layer-selector2 .tab-layers .loading {
+.layer-selector2 .tab-pane {
+    display: none;
+}
+
+.layer-selector2 .tab-pane.active {
+    display: block;
+    height: 100%;
+}
+
+#layer-selector-tab-layers .loading {
     display: none;
     position: absolute;
     top: 0;
@@ -52,11 +51,8 @@
     }
 
 .layer-selector2 .tree-container {
-    position: absolute;
-    right: 0;
-    left: 0;
-    bottom: 40px;
-    top: 44px;
+    height: 100%;
+    width: 103%;
     overflow: auto;
 }
 
@@ -223,27 +219,9 @@
         border: none;
     }
 
-.layer-selector2 dl.tabs dd {
-        cursor: pointer;
-    }
-    .layer-selector2 .tabs {
-        margin-bottom: 0px;
-    }
-    .layer-selector2 .tabs dd, .layer-selector2 .tabs. li {
-        font-weight: 700;
-    }
-    .layer-selector2 .tabs dd.active, .layer-selector2 .tabs li.active {
-        border-top: 2px solid #2ba6cb;
-        margin-top: -2px;
-    }
-    .layer-selector2 .tab-body {
-        display: none;
-    }
-    .layer-selector2 .tab-body.active {
-        display: block;
-        height: 100%;
-    }
-
+.filter-container a.reset {
+    margin-bottom: 0;
+}
 /* See #29 */
 .content .plugin-container-outer .plugin-container {
     padding-bottom: 28px;

--- a/templates.html
+++ b/templates.html
@@ -1,16 +1,18 @@
 ﻿<script type="text/template" id="plugin">
     <div class="layer-selector2">
         <div class="info-box-container"></div>
-        <dl class="tabs">
-          <dd<%= (tab === 'layers' ? ' class="active"' : '') %>>
-            <a data-tab="layers" class="i18n" data-i18n="Layers">Layers</a>
-          </dd>
-          <dd<%= (tab === 'report' ? ' class="active"' : '') %>>
-            <a data-tab="report" class="i18n" data-i18n="Draw &amp; Report">Draw &amp; Report</a>
-          </dd>
-        </dl>
-        <div class="tab-body tab-layers<%= (tab === 'layers' ? ' active' : '') %>"></div>
-        <div class="tab-body tab-report<%= (tab === 'report' ? ' active' : '' ) %>"></div>
+        <ul class="nav nav-tabs" role="tablist">
+          <li<%= (tab === 'layers' ? ' class="active"' : '') %>>
+            <a href="#layer-selector-tab-layers" data-tab="layers" data-toggle="tab" class="i18n" data-i18n="Layers">Layers</a>
+          </li>
+          <li<%= (tab === 'report' ? ' class="active"' : '') %>>
+            <a href="layer-selector-tab-report" data-tab="report" data-toggle="tab" class="i18n" data-i18n="Draw &amp; Report">Draw &amp; Report</a>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div id="layer-selector-tab-layers" role="tabpane" class="tab-pane <%= (tab === 'layers' ? ' active' : '') %>"></div>
+          <div id="layer-selector-tab-report" role="tabpane" class="tab-pane <%= (tab === 'report' ? ' active' : '' ) %>"></div>
+        </div>
     </div>
 </script>
 
@@ -22,9 +24,9 @@
 </script>
 
 <script type="text/template" id="filter">
-    <input type="text" class="filter i18n" data-i18n="[placeholder]Filter Map Layers"
+    <input type="text" class="form-control filter i18n" data-i18n="[placeholder]Filter Map Layers"
            placeholder="Filter Map Layers" value="<%- filterText %>" />
-    <a href="javascript:;" class="reset i18n" data-i18n="Reset Layers">Reset Layers</a>
+    <a href="javascript:;" class="button button-link reset i18n" data-i18n="Reset Layers">Reset Layers</a>
 </script>
 
 <script type="text/template" id="tree">


### PR DESCRIPTION
Updates the tabs, tab panes and a few misc elements to align with the new style guide styles, or just look better.  Also updated some sample layer URLs to get them working again (update your layers.json to get them).

**Before**
![screenshot from 2016-12-29 14 03 56](https://cloud.githubusercontent.com/assets/1014341/21552461/b29819de-cdcf-11e6-9e2d-59039eeef17a.png)

**After**
![screenshot from 2016-12-29 14 04 11](https://cloud.githubusercontent.com/assets/1014341/21552463/b5d9d66e-cdcf-11e6-9ee0-b3716d59473c.png)

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/823

#### Known issues
* Scrolling is hacky, I'm going to check with @jfrankl about how best to do this
* The overlay for the loading spinner now covers the whole map since the pane is no longer absolutely positioned, also going to check on that.

#### Testing
* You'll need to have the updated styleguide commits merged into your framework branch.
* Make sure the equivalent functionality exists, but the styles are up to date.