### PR TITLE
Replace custom tool menu with bootstrap dropdown

### DIFF
--- a/sample_layers.json
+++ b/sample_layers.json
@@ -196,7 +196,10 @@
             "name": "NHC_SeamlessSLOSH_Category1"
         },
         "includeLayers": [
-            { "name": "Inundation Depth " }
+            {
+                "name": "Inundation Depth ",
+                "downloadUrl": "https://raw.githubusercontent.com/CoastalResilienceNetwork/regional-planning/master/README.md"
+            }
         ]
     },
     {

--- a/style.css
+++ b/style.css
@@ -106,13 +106,19 @@
         padding-right: 5px;
         }
         .layer-selector2 .tree-container li > .layer-tools a {
-            width: auto;
+            width: 100%;
         }
         .layer-selector2 .tree-container li.leaf-node:hover > .layer-tools,
         .layer-selector2 .tree-container li.leaf-node.active > .layer-tools,
         .layer-selector2 .tree-container li.parent-node:hover > .layer-tools,
         .layer-selector2 .tree-container li.parent-node.active > .layer-tools {
             display: block;
+        }
+        .layer-selector2 .layer-tools .dropdown {
+            display: inline;
+        }
+        .layer-selector2 .layer-tools .dropdown-menu {
+            left: -140px;
         }
 
 .layer-selector2 .info-box-container {
@@ -167,53 +173,6 @@
             padding: 0;
         }
 
-.layer-selector2-layer-menu {
-        position: absolute;
-        margin-top: -129px;
-        margin-left: -115px;
-        background: #bebebe;
-        color: #414141;
-        width: 140px;
-        z-index: 2000;
-    }
-    .layer-selector2-layer-menu:after {
-        width: 0;
-        height: 0;
-        border-style: solid;
-        border-width: 8px 8px 0 8px;
-        border-color: #bebebe transparent transparent transparent;
-        position: absolute;
-        content: "";
-        right: 6px;
-    }
-    .layer-selector2-layer-menu-shadow {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: #000;
-        opacity: 0;
-        z-index: 900;
-    }
-    .layer-selector2-layer-menu ul {
-        margin: 0;
-    }
-    .layer-selector2-layer-menu li {
-        border-top: 1px solid #999;
-    }
-    .layer-selector2-layer-menu li:first-child {
-        border: none;
-    }
-    .layer-selector2-layer-menu li > a {
-        display: inline-block;
-        width: 100%;
-        color: inherit;
-        padding: 5px;
-    }
-    .layer-selector2-layer-menu li > a[href]:hover {
-        background: #f5f5f5;
-    }
     .layer-selector2-layer-menu li.slider {
         text-align: center;
         border: none;

--- a/templates.html
+++ b/templates.html
@@ -66,7 +66,38 @@
         <div class="layer-tools">
             <a href="javascript:;" class="info"><i class="icon-info-circled <% if (infoBoxIsDisplayed) { %> active <% } %>"></i></a>
             <% if (!layer.isFolder()) { %>
-                <a href="javascript:;" class="more"><i class="icon-ellipsis"></i></a>
+                <div class="dropdown">
+                    <a href="javascript:;" class="dropdown-toggle" data-toggle="dropdown">
+                        <i class="icon-ellipsis"></i>
+                    </a>
+                    <ul class="dropdown-menu" data-layer-id="<%- layer.id() %>">
+                        <% if (layer.getDownloadUrl()) { %>
+                            <li>
+                                <a href="<%- layer.getDownloadUrl() %>" target="_blank" class="download">
+                                    <i class="icon-download"></i>
+                                    <span class="i18n" data-i18n="Download">Download</span>
+                                </a>
+                            </li>
+                        <% } %>
+                        <li>
+                            <a href="javascript:;" class="zoom">
+                                <i class="icon-zoom-in"></i>
+                                <span class="i18n" data-i18n="Zoom to Extent">Zoom to Extent</span>
+                            </a>
+                        </li>
+                        <% if (supportsOpacity) { %>
+                            <li>
+                                <a>
+                                    <i class="icon-adjust"></i>
+                                    <span class="i18n" data-i18n="Opacity">Opacity</span>
+                                </a>
+                            </li>
+                            <li class="slider">
+                                <input type="range" min="0" max="1" step=".1" value="<%= opacity %>"/>
+                            </li>
+                        <% } %>
+                    </ul>
+                </div>
             <% } %>
         </div>
 
@@ -91,37 +122,5 @@
                 </div>
             </div>
         </div>
-    </div>
-</script>
-
-<script type="text/template" id="layer-menu">
-    <div class="layer-selector2-layer-menu" id="<%= id %>" data-layer-id="<%- layer.id() %>">
-        <ul>
-            <% if (layer.getDownloadUrl()) { %>
-                <li>
-                    <a href="<%- layer.getDownloadUrl() %>" target="_blank" class="download">
-                        <i class="icon-download"></i>
-                        <span class="i18n" data-i18n="Download">Download</span>
-                    </a>
-                </li>
-            <% } %>
-            <li>
-                <a href="javascript:;" class="zoom">
-                    <i class="icon-zoom-in"></i>
-                    <span class="i18n" data-i18n="Zoom to Extent">Zoom to Extent</span>
-                </a>
-            </li>
-            <% if (supportsOpacity) { %>
-                <li>
-                    <a>
-                        <i class="icon-adjust"></i>
-                        <span class="i18n" data-i18n="Opacity">Opacity</span>
-                    </a>
-                </li>
-                <li class="slider">
-                    <input type="range" min="0" max="1" step=".1" value="<%= opacity %>"/>
-                </li>
-            <% } %>
-        </ul>
     </div>
 </script>


### PR DESCRIPTION
#### Overview
The tool menu was problematic and was difficult to position correctly. This swaps it out with a bootstrap/mantle dropdown and removes the complex rendering and styling code, but still reuses the existing template and model fields.

Also,  add fake downloadUrl property. This allows the `Tiled Layers > Inundation Depth` layer to show a download link for testing.

**Before**
![screenshot from 2016-12-29 15 34 28](https://cloud.githubusercontent.com/assets/1014341/21554598/d1bdc07a-cdde-11e6-9686-87c26b765566.png)

**After**
![screenshot from 2016-12-29 15 53 38](https://cloud.githubusercontent.com/assets/1014341/21554617/fb8218ac-cdde-11e6-96be-383d8b0410e1.png)

Currently dependant on #70 
Connects #67 

#### Testing
* Test you can still Zoom to Extent for layers which have that enabled
* Test that you can click download link, if enabled (update from `sample_layers.json` to make a layer with a correct setting)