### PR TITLE
Fix Transparency Slider

### DIFF
--- a/main.js
+++ b/main.js
@@ -140,7 +140,7 @@ define([
                     .on('click', 'a.zoom', function() {
                         self.zoomToLayerExtent(self.getClosestLayerId(this));
                     })
-                    .on('change', '#' + this.layerMenuId + ' .slider', function() {
+                    .on('change', '.layer-tools .slider', function() {
                         var layerId = self.getClosestLayerId(this),
                             opacity = parseFloat($(this).find('input').val());
                         self.setLayerOpacity(layerId, opacity);

--- a/main.js
+++ b/main.js
@@ -235,6 +235,8 @@ define([
                     if (service.supportsOpacity()) {
                         var drawingOptions = this.getDrawingOptions(layers),
                             mapLayer = this.map.getLayer(serviceUrl);
+
+                        mapLayer.setImageFormat('png32');
                         mapLayer.setLayerDrawingOptions(drawingOptions);
                     }
                 }, this);


### PR DESCRIPTION
## Overview

The previously used selector `#layer-selector2-layer-menu-1` no longer exists, thus we use `.layer-tools` instead.

Furthermore, it was observed in #66 that opacity adjustments would make layers lighter, but not fainter:

![image](https://cloud.githubusercontent.com/assets/1430060/21658510/fbaf938a-d294-11e6-9188-b7ceb23a1c79.png)

By switching from `png8` to `png32` as the image format, we achieve true transparency:

![image](https://cloud.githubusercontent.com/assets/1430060/21659592/7b0570f6-d299-11e6-9591-b9d8b9a45aac.png)

### Notes

At one point I was attempting to use CSS Opacity instead of ArcGIS options to set transparency. Unfortunately, all the layers from the same service are returned as a single image, and thus the CSS Opacity would apply to all layers in the image, not selectively. Thus, we _have_ to use ArcGIS options.

I also found that I cannot simply set the layer to have a `png32` image format when adding it, and it must be set on every interaction. Hopefully this doesn't affect our performance too much. For some background on this see https://geonet.esri.com/thread/89920#comment-622014

## Testing Instructions

Ensure regional planning is installed in Geosite Framework and both have `prototype` branch checked out. Switch regional planning to this PR's branch. Ensure that the opacity sliders do change the opacity of the right layer, and don't affect any other layers. Ensure that the transparent layers can actually be seen through.

Connects #66 
Connects #73 