### PR TITLE
Use proper styling to achieve scrolling

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,8 +4,9 @@
     overflow: hidden;
 }
 
-.layer-selector2 .tab-content {
+.sidebar-content .layer-selector2 .tab-content {
     height: 100%;
+    padding: 0px;
 }
 
 .layer-selector2 ul li ul {
@@ -51,8 +52,7 @@
     }
 
 .layer-selector2 .tree-container {
-    height: 100%;
-    width: 103%;
+    height: calc(100% - 88px);
     overflow: auto;
 }
 


### PR DESCRIPTION
The previous styles for .tree-container had known problems with allowing
scrolling.  Combined with recent fixes on the framework side, the scroll
behavior is not appropriate.

Connects #71 

Depends on https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/832

* Ensure that scrollbar on expanded layer list show appropriate height and width.