### PR TITLE
Move info box outside of sidebar

### DIFF
--- a/main.js
+++ b/main.js
@@ -74,6 +74,7 @@ define([
                 this.drawReport = new DrawAndReport(this, $('<div>').get(0));
 
                 this.pluginTmpl = _.template(this.getTemplateById('plugin'));
+                this.infoBoxContainerTmpl = _.template(this.getTemplateById('info-box-container'));
                 this.layersPluginTmpl = _.template(this.getTemplateById('layers-plugin'));
                 this.filterTmpl = _.template(this.getTemplateById('filter'));
                 this.treeTmpl = _.template(this.getTemplateById('tree'));
@@ -120,9 +121,6 @@ define([
                     .on('click', 'a.info', function() {
                         self.state = self.state.setInfoBoxLayerId(self.getClosestLayerId(this));
                         self.showLayerInfo();
-                    })
-                    .on('click', '.info-box .close', function() {
-                        self.hideLayerInfo();
                     })
                     .on('keyup', 'input.filter', function() {
                         var $el = $(this),
@@ -300,6 +298,11 @@ define([
                 var $el = $(this.pluginTmpl({
                     tab: this.state.getTab()
                 }));
+
+                // The info box floats outside of the side bar,
+                // so we attach it to the body.
+                $('body').append($(this.infoBoxContainerTmpl()));
+                this.$infoBoxContainer = $('.info-box-container');
 
                 $el.find('#layer-selector-tab-layers').append($(this.layersPluginTmpl()));
                 $el.find('#layer-selector-tab-report').append(this.drawReport.render());
@@ -489,9 +492,12 @@ define([
                 this.preload().then(function() {
                     self.renderLayerSelector();
                 });
+
+                this.$infoBoxContainer.show();
             },
 
             deactivate: function() {
+                this.$infoBoxContainer.hide();
                 this.drawReport.deactivate();
             },
 
@@ -541,7 +547,11 @@ define([
                             html = self.infoBoxTmpl({
                                 layer: layer
                             });
-                        $(self.container).find('.info-box-container').html(html);
+                        self.$infoBoxContainer
+                            .html(html)
+                            .on('click', '.info-box .close', function() {
+                                self.hideLayerInfo();
+                            });
                     })
                     .otherwise(function(err) {
                         console.error(err);
@@ -549,7 +559,7 @@ define([
             },
 
             hideLayerInfo: function() {
-                $(this.container).find('.info-box-container').empty();
+                this.$infoBoxContainer.empty();
                 this.state = this.state.clearInfoBoxLayerId();
                 this.rebuildTree();
             },

--- a/style.css
+++ b/style.css
@@ -120,14 +120,18 @@
         .layer-selector2 .layer-tools .dropdown-menu {
             left: -140px;
         }
+        .layer-selector2 .layer-selector2-layer-menu li.slider {
+            text-align: center;
+            border: none;
+        }
 
-.layer-selector2 .info-box-container {
+.info-box-container {
     position: absolute;
-    top: 0;
-    left: 100%;
+    top: 100px;
+    left: 590px;
     margin-left: 10px;
     }
-    .layer-selector2 .info-box .body {
+    .info-box-container .info-box .body {
         width: 300px;
         max-height: 400px;
         background: #fff;
@@ -136,7 +140,7 @@
         padding: 10px 10px 0 10px;
         overflow: auto;
     }
-    .layer-selector2 .info-box .close {
+    .info-box-container .info-box .close {
         position: absolute;
         top: 7px;
         right: 7px;
@@ -152,31 +156,26 @@
         width: 24px;
         font-size: 14px;
     }
-    .layer-selector2 .info-box .close:hover {
+    .info-box-container .info-box .close:hover {
         background: #f1f2f2;
         color: #333;
     }
-    .layer-selector2 .info-box .info-label {
+    .info-box-container .info-box .info-label {
         font-weight: bold;
         padding-bottom: 3px;
     }
-    .layer-selector2 .info-box .info-value {
+    .info-box-container .info-box .info-value {
         padding-bottom: 10px;
     }
     /* Neutralize Foundation's zealous table styling so the slider won't look terrible */
-    .layer-selector2 .info-box table {
+    .info-box-container .info-box table {
         background-color: transparent;
         border-width: 0;
         margin: 0;
         }
-        .layer-selector2 .info-box td {
+        .info-box-container .info-box table td {
             padding: 0;
         }
-
-    .layer-selector2-layer-menu li.slider {
-        text-align: center;
-        border: none;
-    }
 
 .filter-container a.reset {
     margin-bottom: 0;

--- a/templates.html
+++ b/templates.html
@@ -1,6 +1,9 @@
+<script type="text/template" id="info-box-container">
+    <div class="info-box-container"></div>
+</script>
+
 ﻿<script type="text/template" id="plugin">
     <div class="layer-selector2">
-        <div class="info-box-container"></div>
         <ul class="nav nav-tabs" role="tablist">
           <li<%= (tab === 'layers' ? ' class="active"' : '') %>>
             <a href="#layer-selector-tab-layers" data-tab="layers" data-toggle="tab" class="i18n" data-i18n="Layers">Layers</a>


### PR DESCRIPTION
This PR makes it so that the info box is visible. Previously, the info-box-container was part of the sidebar and was positioned the right of the sidebar, which required horizontal scrolling to see it. Now it is a child of the body, so it becomes visible without scrolling. This was previously fixed in https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/838, but inadvertantly removed scrolling in the launch pad.

![untitled](https://cloud.githubusercontent.com/assets/1896461/21897455/9cd63fc0-d8b7-11e6-9806-3569a42c5f86.png)

#### Testing
* Check out the branch in https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/842
* Check that the layer info box opens and closes when clicking the X in the box.
* While the info box is open, switch to the Launchpad. The info box should disappear. Then, switch back to Regional Planning. The info box should reappear. 
* While the info box is open, click to open the info box for a different layer. The new content should appear.
* Check that scrolling works in the Launchpad and Regional Planning plugins.