### PR TITLE
Add support for sublayers

### DIFF
--- a/LayerNode.js
+++ b/LayerNode.js
@@ -83,7 +83,7 @@ define([
 
             // Return layer ID defined in the map service.
             getServiceId: function() {
-                return this.node.name;
+                return this.node.id;
             },
 
             getServer: function() {

--- a/sample_layers.json
+++ b/sample_layers.json
@@ -134,7 +134,7 @@
         "server": {
             "type": "ags",
             "layerType": "dynamic",
-            "url": "http://services.coastalresilience.org/arcgis/rest/services/Gulf_of_Mexico/",
+            "url": "http://dev.services.coastalresilience.org/arcgis/rest/services/Gulf_of_Mexico/",
             "name": "Alabama"
         },
         "includeLayers": [


### PR DESCRIPTION
In version 4.x of the API, sublayer visibility is managed via the sublayer property of the MapImageLayer class. The updateMap function is updated to use this new interface.

![image](https://cloud.githubusercontent.com/assets/1042475/22253292/15245488-e21f-11e6-8a9d-77010018c7b1.png)

**Notes**
This implementation only works with services that have support for dynamic layers turned on.

See https://github.com/CoastalResilienceNetwork/regional-planning/issues/79 for more details.

**Testing**
- Check out this branch of the framework https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/851
- Update the Alabama service in `layers.json` to use the following URL: `http://dev.services.coastalresilience.org/arcgis/rest/services/Gulf_of_Mexico/`
- Try toggling on and off the Alabama layers.
- Verify that you can turn on multiple layers at the same time.

Connects to https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/845