### PR TITLE
Render transparency correctly

### DIFF
--- a/main.js
+++ b/main.js
@@ -294,6 +294,8 @@ define([
                     if (service.supportsOpacity()) {
                         var drawingOptions = this.getDrawingOptions(layers),
                             mapLayer = this.map.getLayer(serviceUrl);
+
+                        mapLayer.setImageFormat('png32');
                         mapLayer.setLayerDrawingOptions(drawingOptions);
                     }
                 }, this);


### PR DESCRIPTION
A port of https://github.com/CoastalResilienceNetwork/regional-planning/pull/74. Specifically 33746f5fed3a6f28be7b9ecc548b7440c13f3148.

> The default image format of png8 would blend transparent images against a solid white background, and render that blended image which would not be actually transparent on the front-end. png32 on the other hand renders transparent images correctly, thus is
the preferred image format.

> Unfortunately, it needs to be set before every call, and cannot be used during layer initialization. We must be careful of this potentially overloading the server if many layers are visible.

Connects to #83 
Connects to #82 

### Demo

![image](https://cloud.githubusercontent.com/assets/1042475/23671254/8e0767b6-0338-11e7-9a96-ce21ff3f7c46.png)

### Testing

- Turn on layers in the Alabama service (I believe this is the only server we are using that has support for dynamic layers).
- Adjust the transparency for a layer, and verify that the layer is rendered transparent and not just slightly lighter.