### PR TITLE
Narrow scope for menu item event binding

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,7 +134,7 @@ define([
 
             bindLayerMenuEvents: function() {
                 var self = this;
-                $('body')
+                $(self.container)
                     .on('click', 'a.zoom', function() {
                         self.zoomToLayerExtent(self.getClosestLayerId(this));
                     })


### PR DESCRIPTION
## Overview
The menu items were registered with events bound to `body` which, if
multiple instances of regional-planning were included, would trigger
handlers on incorrect instances, resulting in errors. The previous
implementation of the menu drop down probably necessitated the placement
originally, but it has since been refactored to live in the DOM tree under
the plugin container, and not on body.  The event is registered more
narrowly on the container now.

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/950

## Notes
The bug can be observed at http://dev.maps.oceanwealth.org/
* Open "Blue Carbon", an additional instance of `regional-planning`
* Select a layer and click "Zoom To Extent"
* The `regional-planning` plugin will execute the event handle _it_ has registered and throw an error as the layer is not defined.

## Testing
* Add `regional-planning` on this branch and copy it into a new plugin directory, `blue-carbon`
* Overwrite the layers.json for each plugin from:
  * http://dev.maps.oceanwealth.org/plugins/regional-planning/layers.json
  * http://dev.maps.oceanwealth.org/plugins/blue-carbon/layers.json
* In either `regional-planning` or `blue-carbon` utilize the Zoom To & Opacity tools for a layer.  They should work as expected.