### PR TITLE
Remove local underscore import

### DIFF
--- a/draw_report/main.js
+++ b/draw_report/main.js
@@ -4,11 +4,6 @@
             name: "jquery",
             location: "//ajax.googleapis.com/ajax/libs/jquery/1.9.0",
             main: "jquery.min"
-        },
-        {
-            name: "underscore",
-            location: "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4",
-            main: "underscore-min"
         }
     ]
 });

--- a/main.js
+++ b/main.js
@@ -4,11 +4,6 @@
             name: "jquery",
             location: "//ajax.googleapis.com/ajax/libs/jquery/1.9.0",
             main: "jquery.min"
-        },
-        {
-            name: "underscore",
-            location: "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3",
-            main: "underscore-min"
         }
     ]
 });


### PR DESCRIPTION
## Overview

Issues referencing underscore in plugins was remedied in https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/669. Local imports of underscore are no longer needed and cause conflicts with the framework version of underscore when they exist.

## Testing

- Bring up an instance of the framework on `develop`, and add this plugin.
- Ensure the plugin loads and layers can be added.
  