### PR TITLE
Remove custom print

### DIFF
--- a/main.js
+++ b/main.js
@@ -415,15 +415,6 @@ define([
                 }, this);
             },
 
-            beforePrint: function(printDeferred) {
-                // We can short circuit the plugin print chain by simply
-                // rejecting this deferred object.
-                printDeferred.reject();
-
-                // Trigger an export dialog for this pane.
-                this.app.dispatcher.trigger('export-map:pane-' + this.app.paneNumber);
-            },
-
             showSpinner: function() {
                 $(this.container).find('#layer-selector-tab-layers .loading').show();
             },

--- a/overrides.json
+++ b/overrides.json
@@ -2,5 +2,5 @@
     "name": "Regional Planning",
     "description": "Configure and control layers to be overlayed on the base map.",
     "size": "small",
-    "hasCustomPrint": true
+    "hasCustomPrint": false
 }


### PR DESCRIPTION
## Overview

This was not maintained with the recent updates to the print process, nor was the functionality it was demoing utilized by plugin developers.

Related to https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1065

### Testing

- Verify that the plugin print button is no longer present in the header for this plugin.