### PR TITLE
Translate layer options

### DIFF
--- a/main.js
+++ b/main.js
@@ -330,6 +330,10 @@ define([
                     renderLayer: _.bind(this.renderLayer, this, 0)
                 });
                 $(this.container).find('.tree-container').html(html);
+
+                if ($.i18n) {
+                    $(this.container).localize();
+                }
             }, 5),
 
             renderLayer: function(indent, layer) {


### PR DESCRIPTION
Ensure the layer options elements are translated. Since they are not rendered at the time when the rest of the plugin is translated and rendered, they have to be explicitly translated when they are rendered.

Tested as part of https://github.com/CoastalResilienceNetwork/GeositeFramework/pull/1109

Connects https://github.com/CoastalResilienceNetwork/GeositeFramework/issues/1104