### PR TITLE
Update sample_layers.json

### DIFF
--- a/sample_layers.json
+++ b/sample_layers.json
@@ -188,21 +188,6 @@
         ]
     },
     {
-        "displayName": "Tiled layers",
-        "server": {
-            "type": "ags",
-            "layerType": "tiled",
-            "url": "http://tiles.arcgis.com/tiles/C8EMgrsFcRFL6LrL/arcgis/rest/services/",
-            "name": "NHC_SeamlessSLOSH_Category1"
-        },
-        "includeLayers": [
-            {
-                "name": "Inundation Depth ",
-                "downloadUrl": "https://raw.githubusercontent.com/CoastalResilienceNetwork/regional-planning/master/README.md"
-            }
-        ]
-    },
-    {
         "name": "St Vincent and the Grenadines",
         "server": {
             "type": "ags",


### PR DESCRIPTION
Remove demo tile layers, which were the cause of #100.

## Note

This does not solve #100, but allows us to avoid it for now until there is a real need to support authenticated layers.

## Testing instructions ##

- Update your local `layers.json` to match the `sample_layers.json` updated on this branch (or just remove the tiled layers from your local `layers.json`.
- Verify that when opening the regional planning plugin, no authentication window opens.