### PR TITLE
Fix capitalization of xmlToJSON import

### DIFF
--- a/WmsService.js
+++ b/WmsService.js
@@ -2,7 +2,7 @@ define([
         "dojo/_base/declare",
         "dojo/Deferred",
         "underscore",
-        "./lib/xmlToJson",
+        "./lib/xmlToJSON",
         "framework/util/ajax",
         "./util",
         "./LayerNode",


### PR DESCRIPTION
## Overview

Match the capitalization of the the library import to that of the library file name.

Fixes an issue that breaks this plugin when serving the static version of the framework from Linux using the development server.

Connects to https://github.com/CoastalResilienceNetwork/geosite-framework-build/issues/37

## Testing instructions

- Tested through https://github.com/CoastalResilienceNetwork/geosite-framework-build/pull/38